### PR TITLE
TE-7332 Backport for facade methods CategoryFacade::getCategoryListUrl() and CategoryFacade::getNodePath()

### DIFF
--- a/src/Spryker/Zed/Category/Business/CategoryFacade.php
+++ b/src/Spryker/Zed/Category/Business/CategoryFacade.php
@@ -7,6 +7,7 @@
 
 namespace Spryker\Zed\Category\Business;
 
+use Generated\Shared\Transfer\CategoryCollectionTransfer;
 use Generated\Shared\Transfer\CategoryTransfer;
 use Generated\Shared\Transfer\LocaleTransfer;
 use Generated\Shared\Transfer\NodeTransfer;
@@ -14,10 +15,10 @@ use Spryker\Zed\Kernel\Business\AbstractFacade;
 
 /**
  * @method \Spryker\Zed\Category\Business\CategoryBusinessFactory getFactory()
+ * @method \Spryker\Zed\Category\Persistence\CategoryRepositoryInterface getRepository()
  */
 class CategoryFacade extends AbstractFacade implements CategoryFacadeInterface
 {
-
     /**
      * @api
      *
@@ -579,4 +580,30 @@ class CategoryFacade extends AbstractFacade implements CategoryFacadeInterface
             ->touchCategoryActive($idCategory);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
+     * @param int $idNode
+     * @param \Generated\Shared\Transfer\LocaleTransfer $localeTransfer
+     *
+     * @return string
+     */
+    public function getNodePath(int $idNode, LocaleTransfer $localeTransfer): string
+    {
+        return $this->getRepository()->getCategoryNodePath($idNode, $localeTransfer);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getCategoryListUrl(): string
+    {
+        return $this->getFactory()->getConfig()->getDefaultRedirectUrl();
+    }
 }

--- a/src/Spryker/Zed/Category/Business/CategoryFacadeInterface.php
+++ b/src/Spryker/Zed/Category/Business/CategoryFacadeInterface.php
@@ -7,13 +7,13 @@
 
 namespace Spryker\Zed\Category\Business;
 
+use Generated\Shared\Transfer\CategoryCollectionTransfer;
 use Generated\Shared\Transfer\CategoryTransfer;
 use Generated\Shared\Transfer\LocaleTransfer;
 use Generated\Shared\Transfer\NodeTransfer;
 
 interface CategoryFacadeInterface
 {
-
     /**
      * @api
      *
@@ -64,6 +64,7 @@ interface CategoryFacadeInterface
     /**
      * Specification:
      *  - Finds all category-node entities for idCategory
+     *  - Category-node entities sorted by node order
      *  - Returns hydrated NodeTransfer collection
      *
      * @api
@@ -351,6 +352,7 @@ interface CategoryFacadeInterface
      * Specification:
      *  - Finds first category-node for idCategory and finds all of its children
      *  - Formats all child category-nodes as a nested array structure
+     *  - Category-node entities sorted by node order
      *  - Returns array representation of sub-tree
      *
      * @api
@@ -424,4 +426,26 @@ interface CategoryFacadeInterface
      */
     public function getSubTreeByIdCategoryNodeAndLocale($idCategoryNode, LocaleTransfer $localeTransfer);
 
+    /**
+     * Specification:
+     * - Retrieve category node path.
+     *
+     * @api
+     *
+     * @param int $idNode
+     * @param \Generated\Shared\Transfer\LocaleTransfer $localeTransfer
+     *
+     * @return string
+     */
+    public function getNodePath(int $idNode, LocaleTransfer $localeTransfer): string;
+
+    /**
+     * Specification:
+     * - Retrieve url to category list.
+     *
+     * @api
+     *
+     * @return string
+     */
+    public function getCategoryListUrl(): string;
 }

--- a/src/Spryker/Zed/Category/CategoryConfig.php
+++ b/src/Spryker/Zed/Category/CategoryConfig.php
@@ -22,4 +22,19 @@ class CategoryConfig extends AbstractBundleConfig
      */
     const RESOURCE_TYPE_NAVIGATION = 'navigation';
 
+    protected const REDIRECT_URL_DEFAULT = '/category/root';
+
+    protected const REDIRECT_URL_CATEGORY_GUI = '/category-gui/list';
+
+    /**
+     * @return string
+     */
+    public function getDefaultRedirectUrl(): string
+    {
+        if (class_exists('\Spryker\Zed\CategoryGui\Communication\Controller\ListController')) {
+            return static::REDIRECT_URL_CATEGORY_GUI;
+        }
+
+        return static::REDIRECT_URL_DEFAULT;
+    }
 }

--- a/src/Spryker/Zed/Category/CategoryConfig.php
+++ b/src/Spryker/Zed/Category/CategoryConfig.php
@@ -7,6 +7,7 @@
 
 namespace Spryker\Zed\Category;
 
+use Spryker\Zed\CategoryGui\Communication\Controller\ListController;
 use Spryker\Zed\Kernel\AbstractBundleConfig;
 
 class CategoryConfig extends AbstractBundleConfig
@@ -31,7 +32,7 @@ class CategoryConfig extends AbstractBundleConfig
      */
     public function getDefaultRedirectUrl(): string
     {
-        if (class_exists('\Spryker\Zed\CategoryGui\Communication\Controller\ListController')) {
+        if (class_exists(ListController::class)) {
             return static::REDIRECT_URL_CATEGORY_GUI;
         }
 

--- a/src/Spryker/Zed/Category/Persistence/CategoryPersistenceFactory.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryPersistenceFactory.php
@@ -11,17 +11,20 @@ use Orm\Zed\Category\Persistence\SpyCategoryAttributeQuery;
 use Orm\Zed\Category\Persistence\SpyCategoryClosureTableQuery;
 use Orm\Zed\Category\Persistence\SpyCategoryNodeQuery;
 use Orm\Zed\Category\Persistence\SpyCategoryQuery;
+use Orm\Zed\Category\Persistence\SpyCategoryTemplateQuery;
 use Orm\Zed\Url\Persistence\SpyUrlQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
+use Spryker\Zed\Category\Persistence\Propel\Mapper\CategoryMapper;
+use Spryker\Zed\Category\Persistence\Propel\Mapper\CategoryMapperInterface;
 use Spryker\Zed\Kernel\Persistence\AbstractPersistenceFactory;
 
 /**
  * @method \Spryker\Zed\Category\CategoryConfig getConfig()
- * @method \Spryker\Zed\Category\Persistence\CategoryQueryContainer getQueryContainer()
+ * @method \Spryker\Zed\Category\Persistence\CategoryQueryContainerInterface getQueryContainer()
+ * @method \Spryker\Zed\Category\Persistence\CategoryRepositoryInterface getRepository()
  */
 class CategoryPersistenceFactory extends AbstractPersistenceFactory
 {
-
     /**
      * @param string|null $modelAlias
      * @param \Propel\Runtime\ActiveQuery\Criteria|null $criteria
@@ -77,4 +80,11 @@ class CategoryPersistenceFactory extends AbstractPersistenceFactory
         return SpyCategoryClosureTableQuery::create($modelAlias, $criteria);
     }
 
+    /**
+     * @return \Spryker\Zed\Category\Persistence\Propel\Mapper\CategoryMapperInterface
+     */
+    public function createCategoryMapper(): CategoryMapperInterface
+    {
+        return new CategoryMapper();
+    }
 }

--- a/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
@@ -80,13 +80,13 @@ class CategoryRepository extends AbstractRepository implements CategoryRepositor
                 ->orderByDepth(Criteria::DESC)
                 ->filterByFkCategoryNodeDescendant($idNode)
                 ->filterByDepth($depth, Criteria::NOT_EQUAL)
-            ->endUse()
-            ->useCategoryQuery()
-            ->useAttributeQuery()
-            ->filterByFkLocale($idLocale)
-            ->endUse()
-            ->endUse()
-            ->setFormatter(new PropelArraySetFormatter());
+                ->endUse()
+                ->useCategoryQuery()
+                ->useAttributeQuery()
+                ->filterByFkLocale($idLocale)
+                ->endUse()
+                ->endUse()
+                ->setFormatter(new PropelArraySetFormatter());
     }
 
     /**

--- a/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
@@ -76,15 +76,15 @@ class CategoryRepository extends AbstractRepository implements CategoryRepositor
     ): SpyCategoryNodeQuery {
         return $this->getFactory()->createCategoryNodeQuery()
             ->useClosureTableQuery()
-            ->orderByFkCategoryNodeDescendant(Criteria::DESC)
-            ->orderByDepth(Criteria::DESC)
-            ->filterByFkCategoryNodeDescendant($idNode)
-            ->filterByDepth($depth, Criteria::NOT_EQUAL)
+                ->orderByFkCategoryNodeDescendant(Criteria::DESC)
+                ->orderByDepth(Criteria::DESC)
+                ->filterByFkCategoryNodeDescendant($idNode)
+                ->filterByDepth($depth, Criteria::NOT_EQUAL)
             ->endUse()
             ->useCategoryQuery()
-            ->useAttributeQuery()
-            ->filterByFkLocale($idLocale)
-            ->endUse()
+                ->useAttributeQuery()
+                    ->filterByFkLocale($idLocale)
+                ->endUse()
             ->endUse()
             ->setFormatter(new PropelArraySetFormatter());
     }

--- a/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Category\Persistence;
+
+use Generated\Shared\Transfer\CategoryCollectionTransfer;
+use Generated\Shared\Transfer\CategoryTransfer;
+use Generated\Shared\Transfer\LocaleTransfer;
+use Orm\Zed\Category\Persistence\Map\SpyCategoryAttributeTableMap;
+use Orm\Zed\Category\Persistence\SpyCategoryNodeQuery;
+use Orm\Zed\Category\Persistence\SpyCategoryQuery;
+use Spryker\Zed\Kernel\Persistence\AbstractRepository;
+use Spryker\Zed\PropelOrm\Business\Model\Formatter\PropelArraySetFormatter;
+use Spryker\Zed\PropelOrm\Business\Runtime\ActiveQuery\Criteria;
+
+/**
+ * @method \Spryker\Zed\Category\Persistence\CategoryPersistenceFactory getFactory()
+ */
+class CategoryRepository extends AbstractRepository implements CategoryRepositoryInterface
+{
+    public const CATEGORY_NODE_PATH_GLUE = ' / ';
+    public const NODE_PATH_NULL_DEPTH = null;
+    public const IS_NOT_ROOT_NODE = 0;
+    protected const COL_CATEGORY_NAME = 'name';
+
+    /**
+     * @param int $idNode
+     * @param \Generated\Shared\Transfer\LocaleTransfer $localeTransfer
+     *
+     * @return string
+     */
+    public function getCategoryNodePath(int $idNode, LocaleTransfer $localeTransfer): string
+    {
+        $nodePathQuery = $this->queryNodePathWithoutRootNode(
+            $idNode,
+            $localeTransfer->getIdLocale(),
+            static::NODE_PATH_NULL_DEPTH
+        );
+
+        return $this->generateNodePathString($nodePathQuery, static::CATEGORY_NODE_PATH_GLUE);
+    }
+
+    /**
+     * @param \Orm\Zed\Category\Persistence\SpyCategoryNodeQuery $nodePathQuery
+     * @param string $glue
+     *
+     * @return string
+     */
+    protected function generateNodePathString(SpyCategoryNodeQuery $nodePathQuery, string $glue): string
+    {
+        $nodePathQuery = $nodePathQuery
+            ->clearSelectColumns()
+            ->addSelectColumn(static::COL_CATEGORY_NAME);
+
+        /** @var string[] $pathTokens */
+        $pathTokens = $nodePathQuery->find();
+
+        return implode($glue, $pathTokens);
+    }
+
+    /**
+     * @param int $idNode
+     * @param int $idLocale
+     * @param int|null $depth
+     *
+     * @return \Orm\Zed\Category\Persistence\SpyCategoryNodeQuery
+     */
+    protected function queryNodePathWithRootNode(
+        int $idNode,
+        int $idLocale,
+        ?int $depth = self::NODE_PATH_NULL_DEPTH
+    ): SpyCategoryNodeQuery {
+        return $this->getFactory()->createCategoryNodeQuery()
+            ->useClosureTableQuery()
+                ->orderByFkCategoryNodeDescendant(Criteria::DESC)
+                ->orderByDepth(Criteria::DESC)
+                ->filterByFkCategoryNodeDescendant($idNode)
+                ->filterByDepth($depth, Criteria::NOT_EQUAL)
+            ->endUse()
+            ->useCategoryQuery()
+            ->useAttributeQuery()
+            ->filterByFkLocale($idLocale)
+            ->endUse()
+            ->endUse()
+            ->setFormatter(new PropelArraySetFormatter());
+    }
+
+    /**
+     * @param int $idNode
+     * @param int $idLocale
+     * @param int|null $depth
+     *
+     * @return \Orm\Zed\Category\Persistence\SpyCategoryNodeQuery
+     */
+    protected function queryNodePathWithoutRootNode(
+        int $idNode,
+        int $idLocale,
+        ?int $depth = self::NODE_PATH_NULL_DEPTH
+    ): SpyCategoryNodeQuery {
+        return $this->queryNodePathWithRootNode($idNode, $idLocale, $depth)
+            ->filterByIsRoot(static::IS_NOT_ROOT_NODE);
+    }
+}

--- a/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
@@ -76,17 +76,17 @@ class CategoryRepository extends AbstractRepository implements CategoryRepositor
     ): SpyCategoryNodeQuery {
         return $this->getFactory()->createCategoryNodeQuery()
             ->useClosureTableQuery()
-                ->orderByFkCategoryNodeDescendant(Criteria::DESC)
-                ->orderByDepth(Criteria::DESC)
-                ->filterByFkCategoryNodeDescendant($idNode)
-                ->filterByDepth($depth, Criteria::NOT_EQUAL)
-                ->endUse()
-                ->useCategoryQuery()
-                ->useAttributeQuery()
-                ->filterByFkLocale($idLocale)
-                ->endUse()
-                ->endUse()
-                ->setFormatter(new PropelArraySetFormatter());
+            ->orderByFkCategoryNodeDescendant(Criteria::DESC)
+            ->orderByDepth(Criteria::DESC)
+            ->filterByFkCategoryNodeDescendant($idNode)
+            ->filterByDepth($depth, Criteria::NOT_EQUAL)
+            ->endUse()
+            ->useCategoryQuery()
+            ->useAttributeQuery()
+            ->filterByFkLocale($idLocale)
+            ->endUse()
+            ->endUse()
+            ->setFormatter(new PropelArraySetFormatter());
     }
 
     /**

--- a/src/Spryker/Zed/Category/Persistence/CategoryRepositoryInterface.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryRepositoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Copyright © 2016-present Spryker Systems GmbH. All rights reserved.
+ * Use of this software requires acceptance of the Evaluation License Agreement. See LICENSE file.
+ */
+
+namespace Spryker\Zed\Category\Persistence;
+
+use Generated\Shared\Transfer\CategoryCollectionTransfer;
+use Generated\Shared\Transfer\CategoryTransfer;
+use Generated\Shared\Transfer\LocaleTransfer;
+
+interface CategoryRepositoryInterface
+{
+    /**
+     * @param int $idNode
+     * @param \Generated\Shared\Transfer\LocaleTransfer $localeTransfer
+     *
+     * @return string
+     */
+    public function getCategoryNodePath(int $idNode, LocaleTransfer $localeTransfer): string;
+}


### PR DESCRIPTION
## PR Description

- Developer(s): @bezpiatovs

- Ticket: https://spryker.atlassian.net/browse/TE-7332

- Release Group: https://release.spryker.com/release-groups/view/3118

- PR Overview: https://release.spryker.com/release/hotfix?type=&pr=https%3A%2F%2Fgithub.com%2Fspryker%2Fcategory%2Fpull%2F2

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Category  | minor                 |                       |
-----------------------------------------

#### Module Category

##### Change log

Fixes

- Introduced backport for facade methods `CategoryFacade::getCategoryListUrl()` and `CategoryFacade::getNodePath()`.
