### PR TITLE
SUPESC-304 backport for getCategoriesByCriteria() method for Category facade

### DIFF
--- a/src/Spryker/Shared/Category/Transfer/category.transfer.xml
+++ b/src/Spryker/Shared/Category/Transfer/category.transfer.xml
@@ -71,6 +71,8 @@
         <property name="idCategory" type="int"/>
         <property name="storeName" type="string"/>
         <property name="localeName" type="string"/>
+        <property name="idLocale" type="int"/>
+        <property name="withNodes" type="bool"/>
         <property name="withChildren" type="bool"/>
         <property name="withChildrenRecursively" type="bool"/>
     </transfer>

--- a/src/Spryker/Zed/Category/Business/CategoryFacade.php
+++ b/src/Spryker/Zed/Category/Business/CategoryFacade.php
@@ -793,4 +793,18 @@ class CategoryFacade extends AbstractFacade implements CategoryFacadeInterface
             ->createCategoryReader()
             ->findCategory($categoryCriteriaTransfer);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CategoryCriteriaTransfer $categoryCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\CategoryCollectionTransfer
+     */
+    public function getCategoriesByCriteria(CategoryCriteriaTransfer $categoryCriteriaTransfer): CategoryCollectionTransfer
+    {
+        return $this->getRepository()->getCategoriesByCriteria($categoryCriteriaTransfer);
+    }
 }

--- a/src/Spryker/Zed/Category/Business/CategoryFacadeInterface.php
+++ b/src/Spryker/Zed/Category/Business/CategoryFacadeInterface.php
@@ -636,4 +636,16 @@ interface CategoryFacadeInterface
      * @return \Generated\Shared\Transfer\CategoryTransfer|null
      */
     public function findCategory(CategoryCriteriaTransfer $categoryCriteriaTransfer): ?CategoryTransfer;
+
+    /**
+     * Specification:
+     * - Retrieves collection with categories filtered by criteria.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CategoryCriteriaTransfer $categoryCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\CategoryCollectionTransfer
+     */
+    public function getCategoriesByCriteria(CategoryCriteriaTransfer $categoryCriteriaTransfer): CategoryCollectionTransfer;
 }

--- a/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
@@ -250,6 +250,21 @@ class CategoryRepository extends AbstractRepository implements CategoryRepositor
     }
 
     /**
+     * @param \Generated\Shared\Transfer\CategoryCriteriaTransfer $categoryCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\CategoryCollectionTransfer
+     */
+    public function getCategoriesByCriteria(CategoryCriteriaTransfer $categoryCriteriaTransfer): CategoryCollectionTransfer
+    {
+        return $this->getFactory()
+            ->createCategoryMapper()
+            ->mapCategoryCollection(
+                $this->applyCategoryFilters($this->getFactory()->createCategoryQuery(), $categoryCriteriaTransfer)->find(),
+                new CategoryCollectionTransfer()
+            );
+    }
+
+    /**
      * @param \Generated\Shared\Transfer\CategoryTransfer $categoryTransfer
      * @param \Generated\Shared\Transfer\CategoryCriteriaTransfer $categoryCriteriaTransfer
      *
@@ -310,6 +325,18 @@ class CategoryRepository extends AbstractRepository implements CategoryRepositor
                         ->filterByLocaleName($categoryCriteriaTransfer->getLocaleName())
                     ->endUse()
                 ->endUse();
+        }
+
+        if ($categoryCriteriaTransfer->getIdLocale()) {
+            $categoryQuery
+                ->joinWithAttribute()
+                ->useAttributeQuery()
+                ->filterByFkLocale($categoryCriteriaTransfer->getIdLocale())
+                ->endUse();
+        }
+
+        if ($categoryCriteriaTransfer->getWithNodes() === true) {
+            $categoryQuery->leftJoinNode();
         }
 
         return $categoryQuery;

--- a/src/Spryker/Zed/Category/Persistence/CategoryRepositoryInterface.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryRepositoryInterface.php
@@ -22,6 +22,13 @@ interface CategoryRepositoryInterface
     public function getAllCategoryCollection(LocaleTransfer $localeTransfer): CategoryCollectionTransfer;
 
     /**
+     * @param \Generated\Shared\Transfer\CategoryCriteriaTransfer $categoryCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\CategoryCollectionTransfer
+     */
+    public function getCategoriesByCriteria(CategoryCriteriaTransfer $categoryCriteriaTransfer): CategoryCollectionTransfer;
+
+    /**
      * @param int $idCategoryNode
      * @param \Generated\Shared\Transfer\LocaleTransfer $localeTransfer
      *


### PR DESCRIPTION
## PR Description

- Developer(s): @oleksandr-stoilovskyi

- Ticket: https://spryker.atlassian.net/browse/SUPESC-304

- PR Overview: https://release.spryker.com/release/pull-request/8044?type=0

- Release Group: https://release.spryker.com/release-groups/view/3388

- Strategy: major

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Category              | minor                 |   |

-----------------------------------------

#### Module Category

##### Change log

Improvements

- Added `CategoryFacadeInterface::getCategoriesByCriteria()`  to dependencies.
- Introduced `CategoryCriteria::idLocale` transfer property.
- Introduced `CategoryCriteria::withNodes` transfer property.
