### PR TITLE
fix for updating url during activating category

### DIFF
--- a/src/Spryker/Zed/Category/Business/Updater/CategoryUrlUpdater.php
+++ b/src/Spryker/Zed/Category/Business/Updater/CategoryUrlUpdater.php
@@ -200,7 +200,11 @@ class CategoryUrlUpdater implements CategoryUrlUpdaterInterface
             }
 
             $urlTransfer->setUrl($urlPath);
-            $this->urlFacade->updateUrl($urlTransfer);
+            if ($urlTransfer->getIdUrl()) {
+                $this->urlFacade->updateUrl($urlTransfer);
+            } else {
+                $this->urlFacade->createUrl($urlTransfer);
+            }
         }
     }
 

--- a/src/Spryker/Zed/Category/Business/Updater/CategoryUrlUpdater.php
+++ b/src/Spryker/Zed/Category/Business/Updater/CategoryUrlUpdater.php
@@ -105,6 +105,13 @@ class CategoryUrlUpdater implements CategoryUrlUpdaterInterface
             ->addIdCategoryNode($categoryTransfer->getIdCategoryOrFail());
 
         $urlTransfers = $this->categoryRepository->getCategoryNodeUrls($categoryNodeUrlCriteriaTransfer);
+        if (empty($urlTransfers) && $categoryTransfer->getIsActive()) {
+            foreach ($categoryTransfer->getLocalizedAttributes() as $categoryLocalizedAttributesTransfer) {
+                $urlTransfers[] = (new UrlTransfer())
+                                    ->setFkLocale($categoryLocalizedAttributesTransfer->getLocaleOrFail()->getIdLocaleOrFail())
+                                    ->setFkResourceCategorynode($nodeTransfer->requireIdCategoryNode()->getIdCategoryNode());
+            }
+        }
 
         foreach ($categoryTransfer->getLocalizedAttributes() as $categoryLocalizedAttributesTransfer) {
             $this->updateCategoryNodeUrlsForLocale(


### PR DESCRIPTION
When we deactivate category (checkbox active in editing category in ZED) we clear fk_resource_categorynode in spy_url and create redirect for this category. But when we try activate category logic can't find url for existing category because  `\Spryker\Zed\Category\Persistence\CategoryRepository::getCategoryNodeUrls` filters by method  `filterByFkResourceCategorynode_In` and value in that column was delete.
This fix return urlTransfers for existing category which hasn't connected spy_url record.

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
