### PR TITLE
Fix depth calculation in closure table and wrong URL updates

### DIFF
--- a/src/Spryker/Zed/Category/Business/Updater/CategoryUrlUpdater.php
+++ b/src/Spryker/Zed/Category/Business/Updater/CategoryUrlUpdater.php
@@ -98,7 +98,7 @@ class CategoryUrlUpdater implements CategoryUrlUpdaterInterface
      */
     public function updateCategoryNodeUrls(CategoryTransfer $categoryTransfer): void
     {
-        $idCategoryNode = $categoryTransfer->getCategoryNodeOrFail()->getIdCategoryNode();
+        $idCategoryNode = $categoryTransfer->getCategoryNodeOrFail()->getIdCategoryNodeOrFail();
 
         $nodeTransfer = (new NodeTransfer())
             ->setIdCategoryNode($idCategoryNode);

--- a/src/Spryker/Zed/Category/Business/Updater/CategoryUrlUpdater.php
+++ b/src/Spryker/Zed/Category/Business/Updater/CategoryUrlUpdater.php
@@ -98,11 +98,13 @@ class CategoryUrlUpdater implements CategoryUrlUpdaterInterface
      */
     public function updateCategoryNodeUrls(CategoryTransfer $categoryTransfer): void
     {
+        $idCategoryNode = $categoryTransfer->getCategoryNodeOrFail()->getIdCategoryNode();
+
         $nodeTransfer = (new NodeTransfer())
-            ->setIdCategoryNode($categoryTransfer->getIdCategoryOrFail());
+            ->setIdCategoryNode($idCategoryNode);
 
         $categoryNodeUrlCriteriaTransfer = (new CategoryNodeUrlCriteriaTransfer())
-            ->addIdCategoryNode($categoryTransfer->getIdCategoryOrFail());
+            ->addIdCategoryNode($idCategoryNode);
 
         $urlTransfers = $this->categoryRepository->getCategoryNodeUrls($categoryNodeUrlCriteriaTransfer);
 

--- a/src/Spryker/Zed/Category/Persistence/CategoryEntityManager.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryEntityManager.php
@@ -403,13 +403,13 @@ class CategoryEntityManager extends AbstractEntityManager implements CategoryEnt
     ): void {
         foreach ($parentCategoryClosureTableEntities as $parentCategoryClosureTableEntity) {
             $depth = $categoryClosureTableEntity->getDepth() + $parentCategoryClosureTableEntity->getDepth() + 1;
-            $categoryClosureTableEntity = $this->createCategoryClosureTableEntity(
+            $newParentCategoryClosureTableEntity = $this->createCategoryClosureTableEntity(
                 $parentCategoryClosureTableEntity->getFkCategoryNode(),
                 $categoryClosureTableEntity->getFkCategoryNodeDescendant(),
                 $depth,
             );
 
-            $categoryClosureTableEntity->save();
+            $newParentCategoryClosureTableEntity->save();
         }
     }
 
@@ -471,13 +471,13 @@ class CategoryEntityManager extends AbstractEntityManager implements CategoryEnt
     ): void {
         foreach ($parentCategoryClosureTableEntities as $parentCategoryClosureTableEntity) {
             $depth = $categoryClosureTableEntity->getDepth() + $parentCategoryClosureTableEntity->getDepth() + 1;
-            $categoryClosureTableEntity = $this->createCategoryClosureTableEntity(
+            $newParentCategoryClosureTableEntity = $this->createCategoryClosureTableEntity(
                 $parentCategoryClosureTableEntity->getFkCategoryNode(),
                 $categoryClosureTableEntity->getFkCategoryNodeDescendant(),
                 $depth,
             );
 
-            $this->persist($categoryClosureTableEntity);
+            $this->persist($newParentCategoryClosureTableEntity);
         }
     }
 


### PR DESCRIPTION
## PR Description

- Fix1: if you use the CategoryFacade->update the spy_category_closure_table:depth values are calculated and updated wrong because the entity object which is passed as function parameter is updated while creation new parent entity within loop but is also the base for the calculation in next loop run and should not be changed
- Fix2: at one place the category ID is used instead of needed category node ID which leads to wrong updates if they differ 

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
