### PR TITLE
CC-20636 Backport for CategoryFacadeInterface::getCategoryCollection().

### DIFF
--- a/src/Spryker/Shared/Category/Transfer/category.transfer.xml
+++ b/src/Spryker/Shared/Category/Transfer/category.transfer.xml
@@ -75,6 +75,12 @@
         <property name="withNodes" type="bool"/>
         <property name="withChildren" type="bool"/>
         <property name="withChildrenRecursively" type="bool"/>
+        <property name="pagination" type="Pagination"/>
+    </transfer>
+
+    <transfer name="Pagination">
+        <property name="limit" type="int"/>
+        <property name="offset" type="int"/>
     </transfer>
 
     <transfer name="Image">

--- a/src/Spryker/Zed/Category/Business/CategoryFacade.php
+++ b/src/Spryker/Zed/Category/Business/CategoryFacade.php
@@ -807,4 +807,18 @@ class CategoryFacade extends AbstractFacade implements CategoryFacadeInterface
     {
         return $this->getRepository()->getCategoriesByCriteria($categoryCriteriaTransfer);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CategoryCriteriaTransfer $categoryCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\CategoryCollectionTransfer
+     */
+    public function getCategoryCollection(CategoryCriteriaTransfer $categoryCriteriaTransfer): CategoryCollectionTransfer
+    {
+        return $this->getRepository()->getCategoriesByCriteria($categoryCriteriaTransfer);
+    }
 }

--- a/src/Spryker/Zed/Category/Business/CategoryFacadeInterface.php
+++ b/src/Spryker/Zed/Category/Business/CategoryFacadeInterface.php
@@ -648,4 +648,18 @@ interface CategoryFacadeInterface
      * @return \Generated\Shared\Transfer\CategoryCollectionTransfer
      */
     public function getCategoriesByCriteria(CategoryCriteriaTransfer $categoryCriteriaTransfer): CategoryCollectionTransfer;
+
+    /**
+     * Specification:
+     * - Retrieves categories from persistence by criteria.
+     * - Uses `CategoryCriteriaTransfer.pagination.limit` and `CategoryCriteriaTransfer.pagination.offset` to paginate results with limit and offset.
+     * - Returns `CategoryCollectionTransfer` filled with found categories.
+     *
+     * @api
+     *
+     * @param \Generated\Shared\Transfer\CategoryCriteriaTransfer $categoryCriteriaTransfer
+     *
+     * @return \Generated\Shared\Transfer\CategoryCollectionTransfer
+     */
+    public function getCategoryCollection(CategoryCriteriaTransfer $categoryCriteriaTransfer): CategoryCollectionTransfer;
 }


### PR DESCRIPTION
Developer(s): @kkicheglovspryker 

Ticket: https://spryker.atlassian.net/browse/CC-20636

Release Group: https://release.spryker.com/release-groups/view/4541

PR Overview: https://release.spryker.com/release/pull-request/9773

Strategy: major

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Category              | minor                 |   |

-----------------------------------------

#### Module Category

##### Change log

Improvements

- Introduced `CategoryFacadeInterface::getCategoryCollection()`  to fetch categories from Persistence with pagination.
- Introduced `CategoryCriteria::pagination` transfer property.
- Introduced `Pagination` transfer.
