### PR TITLE
PBC-334: Backport for CategoryCriteriaTransfer::isRoot

### DIFF
--- a/src/Spryker/Shared/Category/Transfer/category.transfer.xml
+++ b/src/Spryker/Shared/Category/Transfer/category.transfer.xml
@@ -72,6 +72,7 @@
         <property name="storeName" type="string"/>
         <property name="localeName" type="string"/>
         <property name="idLocale" type="int"/>
+        <property name="isRoot" type="bool"/>
         <property name="withNodes" type="bool"/>
         <property name="withChildren" type="bool"/>
         <property name="withChildrenRecursively" type="bool"/>

--- a/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
+++ b/src/Spryker/Zed/Category/Persistence/CategoryRepository.php
@@ -326,6 +326,13 @@ class CategoryRepository extends AbstractRepository implements CategoryRepositor
             $categoryQuery->filterByIdCategory($categoryCriteriaTransfer->getIdCategory());
         }
 
+        if ($categoryCriteriaTransfer->getIsRoot() !== null) {
+            $categoryQuery
+                ->useNodeQuery('node', Criteria::LEFT_JOIN)
+                ->filterByIsRoot($categoryCriteriaTransfer->getIsRoot())
+                ->endUse();
+        }
+
         if ($categoryCriteriaTransfer->getLocaleName()) {
             $categoryQuery
                 ->useAttributeQuery(null, Criteria::LEFT_JOIN)


### PR DESCRIPTION
Developer(s): @bohdan-turchyk-spryker 

Ticket: https://spryker.atlassian.net/browse/PBC-334

Release Group: https://release.spryker.com/release-groups/view/4672

PR Overview: https://release.spryker.com/release/pull-request/9951

Strategy: major

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Category              | minor                 |   |

-----------------------------------------

#### Module Category

##### Change log

Improvements

- Introduced `CategoryCriteria.isRoot` transfer property.
- Adjusted `CategoryFacadeInterface::findCategory()`  to be able to fetch categories where a node is the root node.
